### PR TITLE
Updating _glossary.md "Reporting Fee Pool"

### DIFF
--- a/source/includes/_glossary.md
+++ b/source/includes/_glossary.md
@@ -365,7 +365,7 @@ The Reporting Fee is sent to the [Fee Window](#fee-window) that contains the Mar
 
 ## Reporting Fee Pool
 
-Any [Settlement Fees](#settlement-fees) (in ETH) collected during a [Fee Window](#fee-window) get added to a Reporting Fee Pool. At the end of the Fee Window, the Reporting Fee Pool is paid out to users in proportion to the number of [REP](#rep) they [Staked](#dispute-stake) during that Fee Window. In this way, all users who participate during a Fee Window will receive a portion of the Settlement Fees collected during that Window. Participation includes [Designated](#designated-reporting) or [Open Reporting](#open-reporting), [Challenging](#challenge) an [Outcome](#outcome), or simply purchasing [Participation Tokens](#participation-token) directly.
+Any [Reporting Fees](#reporting-fee) (in ETH) collected during a [Fee Window](#fee-window) get added to a Reporting Fee Pool. At the end of the Fee Window, the Reporting Fee Pool is paid out to users in proportion to the number of [REP](#rep) they [Staked](#dispute-stake) during that Fee Window. In this way, all users who participate during a Fee Window will receive a portion of the Settlement Fees collected during that Window. Participation includes [Designated](#designated-reporting) or [Open Reporting](#open-reporting), [Challenging](#challenge) an [Outcome](#outcome), or simply purchasing [Participation Tokens](#participation-token) directly.
 
 ## Scalar Market
 


### PR DESCRIPTION
I corrected "Any Settlement Fees" to "Any Reporting Fees". Because "Settlement Fees" means "Creator Fees + Reporting Fees", and this pool does not include "Creator Fees".

FYI, this typo is also in the white paper (Footnote No.11). And it has already been reported to Austin in Discord translations channel.