### PR TITLE
Fix some incorrect information about the meta param and other misc info

### DIFF
--- a/source/includes/_simplifiedAPI.md
+++ b/source/includes/_simplifiedAPI.md
@@ -694,6 +694,7 @@ This transaction will fail if:
 * `p._feePerEthInWei` is greater than the maximum fee (0.5 ETH).
 * `p._endTime` has already passed.
 * The Universe is Forking.
+* A connection to an Augur Node has not been established.
 
 NOTE: The account attempting to create the new market must have sufficient REP in order for the market to be created. This is also true when calling `eth_estimateGas`, which essentially does a trial run of the transaction to determine what the gas cost would be to actually run it. 
 
@@ -730,6 +731,7 @@ This transaction will fail if:
 * `p._feePerEthInWei` is greater than the maximum fee (0.5 ETH).
 * `p._endTime` has already passed.
 * The Universe is Forking.
+* A connection to an Augur Node has not been established.
 
 NOTE: The account attempting to create the new market must have sufficient REP in order for the market to be created. This is also true when calling `eth_estimateGas`, which essentially does a trial run of the transaction to determine what the gas cost would be to actually run it. 
 
@@ -767,6 +769,7 @@ This transaction will fail if:
 * `p._feePerEthInWei` is greater than the maximum fee (0.5 ETH).
 * `p._endTime` has already passed.
 * The Universe is Forking.
+* A connection to an Augur Node has not been established.
 
 NOTE: The account attempting to create the new market must have sufficient REP in order for the market to be created. This is also true when calling `eth_estimateGas`, which essentially does a trial run of the transaction to determine what the gas cost would be to actually run it.
 

--- a/source/includes/_simplifiedAPI.md
+++ b/source/includes/_simplifiedAPI.md
@@ -163,7 +163,7 @@ Sends Ether to a specified Ethereum address.
     * **`p.etherToSend`**  (string) Amount of Ether to send, as a base-10 string.
     * **`p.from`**  (string) Ethereum address of the sender, as a 20-byte hexadecimal string.
     * **`p.to`**  (string) Ethereum address of the recipient, as a 20-byte hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Called if/when the transaction is broadcast to the network.
     * **`p.onSuccess`**  (function) Called if/when the transaction is sealed and confirmed.
     * **`p.onFailed`**  (function) Called if/when the transaction fails.
@@ -182,7 +182,7 @@ Sends [REP](#rep) to a specified Ethereum address. This function will trigger a 
     * **`p.universe`**  (string) The universe of Reputation to use.
     * **`p.reputationToSend`**  (string) Amount of Reputation to send, as a base-10 string.
     * **`p._to`**  (string) Ethereum address of the recipient, as a 20-byte hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Called if/when the transaction is broadcast to the network.
     * **`p.onSuccess`**  (function) Called if/when the transaction is sealed and confirmed.
     * **`p.onFailed`**  (function) Called if/when the transaction fails.
@@ -709,7 +709,7 @@ NOTE: The account attempting to create the new market must have sufficient REP i
     * **`p._topic`**  (string) The topic (category) to which this Market belongs, as a UTF8 string. Note: This string is limited to 32-characters.
     * **`p._description`**  (string) Description of the Market, as a UTF8 string.
     * **`p._extraInfo`**  ([ExtraInfo](#ExtraInfo)) &lt;optional> Extra info which will be converted to JSON and logged to the chain in the `MarketCreated` event.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Called if/when the createCategoricalMarket transaction is broadcast to the network.
     * **`p.onSuccess`**  (function) Called if/when the createCategoricalMarket transaction is sealed and confirmed.
     * **`p.onFailed`**  (function) Called if/when the createCategoricalMarket transaction fails.
@@ -747,7 +747,7 @@ NOTE: The account attempting to create the new market must have sufficient REP i
     * **`p._description`**  (string) Description of the Market, as a UTF8 string.
     * **`p.tickSize`**  (string) &lt;optional> The [Tick](#tick) size for this Market, as a base-10 string.
     * **`p._extraInfo`**  (ExtraInfo) &lt;optional> Extra info which will be converted to JSON and logged to the chain in the `MarketCreated` event.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Called if/when the createScalarMarket transaction is broadcast to the network.
     * **`p.onSuccess`**  (function) Called if/when the createScalarMarket transaction is sealed and confirmed.
     * **`p.onFailed`**  (function) Called if/when the createScalarMarket transaction fails.
@@ -781,7 +781,7 @@ NOTE: The account attempting to create the new market must have sufficient REP i
     * **`p._topic`**  (string) The topic (category) to which this Market belongs, as a UTF8 string. Note: This string is limited to 32-characters.
     * **`p._description`**  (string) Description of the Market, as a UTF8 string.
     * **`p._extraInfo`**  ([ExtraInfo](#ExtraInfo)) &lt;optional> Extra info which will be converted to JSON and logged to the chain in the `MarketCreated` event.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Called if/when the createYesNoMarket transaction is broadcast to the network.
     * **`p.onSuccess`**  (function) Called if/when the createYesNoMarket transaction is sealed and confirmed.
     * **`p.onFailed`**  (function) Called if/when the createYesNoMarket transaction fails.
@@ -1696,7 +1696,7 @@ The claiming process works as follows:
     * **`p.redeemer`**  (string) Ethereum address attempting to redeem reporting fees, as a hexadecimal string.
     * **`p.forkedMarket`**  (<a href="#ClaimReportingFeesForkedMarket">ClaimReportingFeesForkedMarket</a>) Object containing information about the Forked Market in which the user has unclaimed fees in the current universe .
     * **`p.estimateGas`**  (boolean) Whether to return gas estimates for the transactions instead of actually making the transactions.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Called if/when the transactions are broadcast to the network. (Currently used as a placeholder and not actually used by this function.)
     * **`p.onSuccess`**  (function) Called if/when all transactions are sealed and confirmed.
     * **`p.onFailed`**  (function) Called if/when all transactions have been attempted and at least one transaction has failed. Error message shows which transactions succeeded and which ones failed.
@@ -1732,7 +1732,7 @@ The claiming process works as follows:
     * **`p.feeWindows`** (Array.&lt;string>) Array of Fee Window Ethereum contract addresses, as hexadecimal strings.
     * **`p.nonforkedMarkets`** (Array.&lt;<a href="#ClaimReportingFeesNonforkedMarket">ClaimReportingFeesNonforkedMarket</a>>) Array of ClaimReportingFeesNonforkedMarket objects.
     * **`p.estimateGas`**  (boolean) Whether to return gas estimates for the transactions instead of actually making the transactions.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Called if/when the transactions are broadcast to the network. (Currently used as a placeholder and not actually used by this function.)
     * **`p.onSuccess`**  (function) Called if/when all transactions are sealed and confirmed.
     * **`p.onFailed`**  (function) Called if/when all transactions have been attempted and at least one transaction has failed. Error message shows which transactions succeeded and which ones failed.
@@ -1755,7 +1755,7 @@ This transaction will fail if:
 
 * **`p`** (Object) Parameters object.
     * **`p.market`**  (string) Address of the Market to Finalize, as a hex string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Called if/when the transaction is broadcast to the network.
     * **`p.onSuccess`**  (function) Called if/when the transaction is sealed and confirmed.
     * **`p.onFailed`**  (function) Called if/when the transaction fails.
@@ -2581,7 +2581,7 @@ Similar to the function `augur.trading.claimTradingProceeds`, but attempts to co
 * **`p`** (Object) Parameters object.
     * **`p.markets`**  (Array.&lt;string>) Array of [Market](#market) addresses for which to claim proceeds.
     * **`p._shareHolder`**  (string) User address that holds the shares, as a 20-byte hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Called if/when each transaction is broadcast to the network.
     * **`p.onSuccess`**  (function) Called if/when all transactions are sealed and confirmed.
     * **`p.onFailed`**  (function) Called if/when any of the transactions fail.
@@ -2604,7 +2604,7 @@ This function will fail if:
 * **`p`** (Object) Parameters object.
     * **`p._market`**  (string) [Market](#market) address for which to claim proceeds.
     * **`p._shareHolder`**  (string) Ethereum address that holds the shares, as a 20-byte hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Called if/when each transaction is broadcast to the network.
     * **`p.onSuccess`**  (function) Called if/when all transactions are sealed and confirmed.
     * **`p.onFailed`**  (function) Called if/when any of the transactions fail.
@@ -2810,7 +2810,7 @@ Rescales a price to lie on [0, 1]: normalizedPrice = (price - minPrice) / (maxPr
     * **`p._outcome`**  (number) Outcome ID to trade, must be an integer value in between 0 and 7.
     * **`p._tradeGroupId`**  (string) &lt;optional> ID logged with each trade transaction, as a hexadecimal string. (This is generally just used by Augur's UI to group trades client-side.)
     * **`p.doNotCreateOrders`**  (boolean) &lt;optional> If set to true, this trade will only take existing Orders off the [Order Book](#order-book), not create new ones Defaults to `false`.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Called when the first trading transaction is broadcast to the network.
     * **`p.onSuccess`**  (function) Called when the full trade completes successfully.
     * **`p.onFailed`**  (function) Called if any part of the trade fails.
@@ -2864,7 +2864,7 @@ If `p.doNotCreateOrders` is set to `false`, this function will place trades unti
     * **`p.maxPrice`**  (string) The [Maximum Display Price](#maximum-display-price) for this Market, as a base-10 string.
     * **`p._tradeGroupId`**  (string) &lt;optional> ID logged with each trade transaction, as a hexadecimal string. (This is generally just used by Augur's UI to group trades client-side.)
     * **`p.doNotCreateOrders`**  (boolean) &lt;optional> If set to true, this trade will only take existing orders off the book, not create new ones. Defaults to `false`.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Called when the first trading transaction is broadcast to the network.
     * **`p.onSuccess`**  (function) Called when the full trade completes successfully.
     * **`p.onFailed`**  (function) Called if any part of the trade fails.

--- a/source/includes/_transactionAPI.md
+++ b/source/includes/_transactionAPI.md
@@ -261,7 +261,7 @@ Allows the caller to create a new [Genesis Universe](#genesis-universe). Users m
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -314,7 +314,7 @@ This function will fail if:
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -423,7 +423,7 @@ Many of the transaction functions in Augur's smart contracts will only work if t
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -444,7 +444,7 @@ Decreases the amount of [Cash](#cash) `p._spender` is approved to spend on behal
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -465,7 +465,7 @@ Increases the amount of [Cash](#cash) `p._spender` is approved to spend on behal
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -486,7 +486,7 @@ Withdraws a certain amount of the user's [Cash](#cash) to a particular address a
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -552,7 +552,7 @@ Calculates the [Reporting Fee](#reporting-fee) that will be paid when settling a
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.send`** (boolean) &lt;optional> Whether this function should be executed as a transaction. When set to `true`, this function will be executed as a transaction, which will calculate the value (and thus uses gas). When set to `false`, this function will be executed as a call, which will return the Reporting Fee amount and will not use any gas. 
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -578,7 +578,7 @@ This transaction will fail if:
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -690,7 +690,7 @@ When successful, this transaction will trigger a [`CompleteSetsPurchased`](#Comp
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.value`**  (string) Number of [attoETH](atto-prefix) required to buy a [Complete Set](#complete-set), as a hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -712,7 +712,7 @@ This function is not fully implemented yet, but is a intended to be a point-of-c
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.value`**  (string) Number of [attoETH](atto-prefix) required to buy a [Complete Set](#complete-set), as a hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -740,7 +740,7 @@ When successful, this transaction will trigger a [`CompleteSetsSold`](#CompleteS
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -761,7 +761,7 @@ This function is not fully implemented yet, but is a intended to be a point-of-c
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -837,7 +837,7 @@ This transaction will fail if:
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.value`**  (string) Number of [attoETH](atto-prefix) required to create the Order, as a hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -924,7 +924,7 @@ This transaction will trigger a [ReportingParticipantDisavowed](#ReportingPartic
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -961,7 +961,7 @@ This transaction will fail if:
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -984,7 +984,7 @@ This transaction will fail if:
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -1072,7 +1072,7 @@ These Participation Tokens can be redeemed later once the Fee Window is no longe
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -1094,7 +1094,7 @@ This transaction will trigger a [`FeeWindowRedeemed`](#FeeWindowRedeemed) event 
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -1117,7 +1117,7 @@ This transaction will fail if:
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -1179,7 +1179,7 @@ This transaction will fail if:
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.value`**  (string) Number of [attoETH](atto-prefix) required to fill the Order, as a hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -1277,7 +1277,7 @@ This transaction will fail if:
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -1299,7 +1299,7 @@ This transaction will trigger an [`InitialReporterRedeemed`](#InitialReporterRed
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -1325,7 +1325,7 @@ This transaction will trigger an [`InitialReporterTransferred`](#InitialReporter
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -1348,7 +1348,7 @@ This transaction will fail if:
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -1431,7 +1431,7 @@ This transaction will fail if:
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -1454,7 +1454,7 @@ This transaction will fail if:
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -1478,7 +1478,7 @@ This transaction will fail if:
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -1646,7 +1646,7 @@ This function will fail if:
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -1673,7 +1673,7 @@ This function will fail if:
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -1700,7 +1700,7 @@ This transaction will fail if:
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -1725,7 +1725,7 @@ This transaction will fail if:
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -1749,7 +1749,7 @@ This transaction will fail if:
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -1773,7 +1773,7 @@ This transaction will fail if:
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -1797,7 +1797,7 @@ This transaction will fail if:
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -1820,7 +1820,7 @@ This transaction will fail if:
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -2024,7 +2024,7 @@ Allows `p._spender` to spend up to `p._value` [REP](#rep) for the `msg.sender` o
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -2045,7 +2045,7 @@ Decreases the amount of [REP](#rep) `p._spender` is approved to spend on behalf 
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -2066,7 +2066,7 @@ Increases the amount of [REP](#rep) `p._spender` is approved to spend on behalf 
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -2085,7 +2085,7 @@ Migrates [Legacy REP](#legacy-rep) tokens owned by `msg.sender` from the [Legacy
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -2111,7 +2111,7 @@ This transaction will fail if:
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -2138,7 +2138,7 @@ This transaction will fail if:
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -2163,7 +2163,7 @@ This transaction will fail if:
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -2190,7 +2190,7 @@ This transaction will fail if:
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -2209,7 +2209,7 @@ Gets the current [Theoretical REP Supply](#theoretical-rep-supply) for this Repu
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -2234,7 +2234,7 @@ This transaction will fail if:
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -2359,7 +2359,7 @@ Allows `p._spender` to spend up to `p._value` [Shares](#share) for the `msg.send
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -2380,7 +2380,7 @@ Decreases the amount of [Shares](#share) `p._spender` is approved to spend on be
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -2401,7 +2401,7 @@ Increases the amount of [Shares](#share) `p._spender` is approved to spend on be
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -2426,7 +2426,7 @@ This transaction will fail if:
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -2453,7 +2453,7 @@ This transaction will fail if:
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -2691,7 +2691,7 @@ This transaction will fail if:
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.value`**  (string) Number of [attoETH](atto-prefix) required to buy the desired amount of Share Units, as a hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -2719,7 +2719,7 @@ Works like `augur.api.Trade.publicBuy`, but uses the parameter `_loopLimit` to d
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.value`**  (string) Number of [attoETH](atto-prefix) required to buy the desired amount of Share Units, as a hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -2745,7 +2745,7 @@ Works similarly to `augur.api.Trade.publicTrade`, except it does not create an [
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.value`**  (string) Number of [Share Units](#share-unit) to sell, as a hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -2772,7 +2772,7 @@ Works like `augur.api.Trade.publicFillBestOrder`, but uses the parameter `_loopL
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.value`**  (string) Number of [Share Units](#share-unit) to sell, as a hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -2803,7 +2803,7 @@ This transaction will fail if:
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.value`**  (string) Number of [Share Units](#share-unit) to sell, as a hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -2831,7 +2831,7 @@ Works like `augur.api.Trade.publicSell`, but uses the parameter `_loopLimit` to 
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.value`**  (string) Number of [Share Units](#share-unit) to sell, as a hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -2863,7 +2863,7 @@ The value of the Order (calculated as p._price * (Market’s number of Ticks - p
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.value`**  (string) Number of [attoETH](atto-prefix) required to buy the desired amount of Share Units, or number of Share Units to sell, as a hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -2892,7 +2892,7 @@ Works like `augur.api.Trade.publicTrade`, but uses the parameter `_loopLimit` to
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.value`**  (string) Number of [attoETH](atto-prefix) required to buy the desired amount of Share Units, or number of Share Units to sell, as a hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -2960,7 +2960,7 @@ This transaction will fail if:
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -2985,7 +2985,7 @@ This transaction will fail if:
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.send`** (boolean) &lt;optional> Whether this function should be executed as a transaction. When set to `true`, this function will be executed as a transaction, which will calculate the value (and thus uses gas). When set to `false`, this function will be executed as a call, which will return the value of the user's Shares in the Market, in that Market's denomination token.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -3299,7 +3299,7 @@ NOTE: The account attempting to create the new market must have sufficient REP i
         * **`p.tx.to`**  (string) Ethereum address of the Universe contract to run the transaction on, as a 20-byte hexadecimal value.
         * **`p.tx.value`**  (string) Number of [attoETH](atto-prefix) required to create the Market, as a hexadecimal string. This can be obtained by calling `augur.createMarket.getMarketCreationCost` and multiplying the `etherRequiredToCreateMarket` value that's returned by 10<sup>18</sup>.
         * **`p.tx.gas`**  (string) Gas limit to use when submitting this transaction, as a hexadecimal string. This can be obtained from the constant `augur.constants.CREATE_CATEGORICAL_MARKET_GAS`.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -3325,7 +3325,7 @@ This transaction will fail if:
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -3369,7 +3369,7 @@ NOTE: The account attempting to create the new market must have sufficient REP i
         * **`p.tx.to`**  (string) Ethereum address of the Universe contract to run the transaction on, as a 20-byte hexadecimal value.
         * **`p.tx.value`**  (string) Number of [attoETH](atto-prefix) required to create the Market, as a hexadecimal string. This can be obtained by calling `augur.createMarket.getMarketCreationCost` and multiplying the `etherRequiredToCreateMarket` value that's returned by 10<sup>18</sup>.
         * **`p.tx.gas`**  (string) Gas limit to use when submitting this transaction, as a hexadecimal string. This can be obtained from the constant `augur.constants.CREATE_SCALAR_MARKET_GAS`.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -3409,7 +3409,7 @@ NOTE: The account attempting to create the new market must have sufficient REP i
         * **`p.tx.to`**  (string) Ethereum address of the Universe contract to run the transaction on, as a 20-byte hexadecimal value.
         * **`p.tx.value`**  (string) Number of [attoETH](atto-prefix) required to create the Market, as a hexadecimal string. This can be obtained by calling `augur.createMarket.getMarketCreationCost` and multiplying the `etherRequiredToCreateMarket` value that's returned by 10<sup>18</sup>.
         * **`p.tx.gas`**  (string) Gas limit to use when submitting this transaction, as a hexadecimal string. This can be obtained from the constant `augur.constants.CREATE_YES_NO_MARKET_GAS`.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.    
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.    
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -3429,7 +3429,7 @@ Returns either the size of the [No-Show Bond](#no-show-bond) or the size of the 
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.send`** (boolean) &lt;optional> Whether this function should be executed as a transaction. When set to `true`, this function will be executed as a transaction, which will calculate the value (and thus uses gas). When set to `false`, this function will be executed as a call, which will return the [Initial Report](#initial-report) Stake size and will not use any gas. 
         * **`p.tx.gas`** (string) &lt;optional> Gas limit to use when submitting this transaction, as a hexadecimal string. This does not need to be set if `p.tx.send` is `false`.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -3449,7 +3449,7 @@ Gets the [No-Show Bond](#no-show-bond) for [Markets](#market) in the specified [
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.send`** (boolean) &lt;optional> Whether this function should be executed as a transaction. When set to `false`, this function will be executed as a call, which will simply return the last value that was cached (and will not use any gas). When set to `true`, this function will be executed as a transaction, which will use gas to re-calculate the value and cache it. (However, the return value will not be [obtainable](#transaction-return-values).)
         * **`p.tx.gas`** (string) &lt;optional> Gas limit to use when submitting this transaction, as a hexadecimal string. This does not need to be set if `p.tx.send` is `false`.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -3469,7 +3469,7 @@ Gets the amount of Staked [REP](#rep) the [Designated Reporter](#designated-repo
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.send`** (boolean) &lt;optional> Whether this function should be executed as a transaction. When set to `false`, this function will be executed as a call, which will simply return the last value that was cached (and will not use any gas). When set to `true`, this function will be executed as a transaction, which will use gas to re-calculate the value and cache it. (However, the return value will not be [obtainable](#transaction-return-values).)
         * **`p.tx.gas`** (string) &lt;optional> Gas limit to use when submitting this transaction, as a hexadecimal string. This does not need to be set if `p.tx.send` is `false`.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -3489,7 +3489,7 @@ Gets the estimated amount of [attoETH](#atto-prefix) required to create a [Marke
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.send`** (boolean) &lt;optional> Whether this function should be executed as a transaction. When set to `false`, this function will be executed as a call, which will simply return the last value that was cached (and will not use any gas). When set to `true`, this function will be executed as a transaction, which will use gas to re-calculate the value and cache it. (However, the return value will not be [obtainable](#transaction-return-values).)
         * **`p.tx.gas`** (string) &lt;optional> Gas limit to use when submitting this transaction, as a hexadecimal string. This does not need to be set if `p.tx.send` is `false`.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -3509,7 +3509,7 @@ Gets the number by which the total payout amount for a [Market](#market) is divi
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.send`** (boolean) &lt;optional> Whether this function should be executed as a transaction. When set to `false`, this function will be executed as a call, which will simply return the last value that was cached (and will not use any gas). When set to `true`, this function will be executed as a transaction, which will use gas to re-calculate the value and cache it. (However, the return value will not be [obtainable](#transaction-return-values).)
         * **`p.tx.gas`** (string) &lt;optional> Gas limit to use when submitting this transaction, as a hexadecimal string. This does not need to be set if `p.tx.send` is `false`.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -3529,7 +3529,7 @@ Gets the amount the [Market Creator](#market-creator) must pay for the [Validity
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.send`** (boolean) &lt;optional> Whether this function should be executed as a transaction. When set to `false`, this function will be executed as a call, which will simply return the last value that was cached (and will not use any gas). When set to `true`, this function will be executed as a transaction, which will use gas to re-calculate the value and cache it. (However, the return value will not be [obtainable](#transaction-return-values).)
         * **`p.tx.gas`** (string) &lt;optional> Gas limit to use when submitting this transaction, as a hexadecimal string. This does not need to be set if `p.tx.send` is `false`.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -3549,7 +3549,7 @@ Gets the Ethereum contract address of the [Fee Window](#fee-window) that is curr
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.send`** (boolean) &lt;optional> Whether this function should be executed as a transaction. When set to `false`, this function will be executed as a call, which will simply return the last value that was cached (and will not use any gas). When set to `true`, this function will be executed as a transaction, which will use gas to re-calculate the value and cache it. (However, the return value will not be [obtainable](#transaction-return-values).)
         * **`p.tx.gas`** (string) &lt;optional> Gas limit to use when submitting this transaction, as a hexadecimal string. This does not need to be set if `p.tx.send` is `false`.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -3570,7 +3570,7 @@ Gets the Ethereum contract address of the active [Fee Window](#fee-window) at th
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.send`** (boolean) &lt;optional> Whether this function should be executed as a transaction. When set to `false`, this function will be executed as a call, which will simply return the last value that was cached (and will not use any gas). When set to `true`, this function will be executed as a transaction, which will use gas to re-calculate the value and cache it. (However, the return value will not be [obtainable](#transaction-return-values).)
         * **`p.tx.gas`** (string) &lt;optional> Gas limit to use when submitting this transaction, as a hexadecimal string. This does not need to be set if `p.tx.send` is `false`.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -3590,7 +3590,7 @@ Gets the Ethereum contract address of the [Fee Window](#fee-window) that will be
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.send`** (boolean) &lt;optional> Whether this function should be executed as a transaction. When set to `false`, this function will be executed as a call, which will simply return the last value that was cached (and will not use any gas). When set to `true`, this function will be executed as a transaction, which will use gas to re-calculate the value and cache it. (However, the return value will not be [obtainable](#transaction-return-values).)
         * **`p.tx.gas`** (string) &lt;optional> Gas limit to use when submitting this transaction, as a hexadecimal string. This does not need to be set if `p.tx.send` is `false`.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -3610,7 +3610,7 @@ Gets the Ethereum contract address of the [Fee Window](#fee-window) that was act
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.send`** (boolean) &lt;optional> Whether this function should be executed as a transaction. When set to `false`, this function will be executed as a call, which will simply return the last value that was cached (and will not use any gas). When set to `true`, this function will be executed as a transaction, which will use gas to re-calculate the value and cache it. (However, the return value will not be [obtainable](#transaction-return-values).)
         * **`p.tx.gas`** (string) &lt;optional> Gas limit to use when submitting this transaction, as a hexadecimal string. This does not need to be set if `p.tx.send` is `false`.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.
@@ -3631,7 +3631,7 @@ Calls the `redeem` function for all Ethereum contract addresses in the arrays `p
     * **`p.tx`** (Object) Object containing details about how this transaction should be made.
         * **`p.tx.to`** (string) Ethereum contract address on which to call this function, as a 20-byte hexadecimal string.
         * **`p.tx.gas`** (string) Gas limit to use when submitting this transaction, as a hexadecimal string.
-    * **`p.meta`**  (<a href="#Meta">Meta</a>) &lt;optional> Authentication metadata for raw transactions.
+    * **`p.meta`**  (<a href="#Meta">Meta</a>) Authentication metadata for raw transactions.
     * **`p.onSent`**  (function) Callback function that executes once the transaction has been sent.
     * **`p.onSuccess`**  (function) &lt;optional> Callback function that executes if the transaction returned successfully.
     * **`p.onFailed`**  (function) &lt;optional> Callback function that executes if the transaction failed.

--- a/source/includes/_transactionAPI.md
+++ b/source/includes/_transactionAPI.md
@@ -89,7 +89,7 @@ The other properties that can be specified in the `tx` object are discussed in t
 
 ### The `meta` Object
 
-All Transaction API functions accept a `meta` object as a parameter in order to sign the transaction. The `meta` object contains a `signer` property, which should be set to the private key buffer or a signing function, provided by a hardware wallet, of the account that wishes to initiate the transaction. (When logged in using an Edge account, the private key buffer can be obtained by outputting the value `state.loginAccount.meta.signer`.) The `meta` object also contains an `accountType` property, which should be set to "privateKey", "ledger", "trezor", "edge", or "unlockedEthereumNode". The Transaction API functions attempt to modify information on the blockchain, which requires the transaction to be signed. The `meta` parameter is not required when calling Transaction API functions while using MetaMask (which will pop up a separate window asking to confirm the transaction).
+All Transaction API functions accept a `meta` object as a parameter in order to sign the transaction. The `meta` object contains a `signer` property, which should be set to the private key buffer or a signing function, provided by a hardware wallet, of the account that wishes to initiate the transaction. (When logged in using an Edge account, the private key buffer can be obtained by outputting the value `state.loginAccount.meta.signer`.) The `meta` object also contains an `accountType` property, which should be set to "privateKey", "ledger", "trezor", "edge", "metaMask", or "unlockedEthereumNode". The Transaction API functions attempt to modify information on the blockchain, which requires the transaction to be signed.
 
 ### Callbacks
 

--- a/source/includes/_typeDefinitions.md
+++ b/source/includes/_typeDefinitions.md
@@ -377,7 +377,7 @@ Serves as an enum for the state of a Dispute Token.
 Authentication metadata for raw transactions.
 
 #### **Properties:** 
-* **`accountType`** (string) Type of account that is signing the transaction. Possible values include "privateKey", "ledger", "trezor", "edge", and "unlockedEthereumNode".
+* **`accountType`** (string) Type of account that is signing the transaction. Possible values include "privateKey", "ledger", "trezor", "edge", "metaMask" and "unlockedEthereumNode".
 * **`address`** (string) Ethereum address that is making the transaction, as a hexadecimal string.
 * **`signer`** (buffer|function) Private key buffer or a signing function provided by a hardware wallet, of the account initiating the transaction.
 


### PR DESCRIPTION
When using metaMask the meta parameter is not optional as the docs suggest it is. Also metaMask isn't provided as an example at all for the accountType attribute of the meta param. I edited some text to fix these problems. Mostly removing all of the optional tags from api calls requiring the meta param. Note that I have only tested those in the simplified API and have not tested if they are actually optional in the Tx API, but I figure that they are not because that would be pretty strange. Also The createMarket functions in the simplified API will fail if they are not connected to an Augur Node, so I added a warning in the "This transaction will fail if:" section on those methods.

:)